### PR TITLE
More reliable yum package tests

### DIFF
--- a/lib/puppet/provider/multipkg/yum.rb
+++ b/lib/puppet/provider/multipkg/yum.rb
@@ -1,6 +1,6 @@
 Puppet::Type.type(:multipkg).provide(:yum) do
 commands :yum => '/usr/bin/yum'
-commands :rpm => '/usr/bin/rpm'
+commands :rpm => '/bin/rpm'
 
   def exists?
     desired_packages = []
@@ -15,26 +15,30 @@ commands :rpm => '/usr/bin/rpm'
         # Save all packages to verify later
         desired_packages << package
         # We need to take off arch because rpm command doesn't accept them
-        yum_lookup_arr = desired_packages.map {|item| item.split(".").first }
+        yum_lookup_arr << package.sub(/\.(i686|x86_64)$/, '')
       end
     }
 
     # Test yum packages
-    output = pkg_list("list", yum_lookup_arr)
-    # Verify each package
-    for pkg in desired_packages
-      # DEBUG: puts "checking " + pkg
-      # DEBUG: puts output.grep(/^#{Regexp.escape pkg}/).to_s
-      # All returned packages have arch so we should check if they start with string, not match
-      unless output.grep(/^#{Regexp.escape pkg}/).size > 0
-        return false
+    if desired_packages.any? then
+      output = pkg_list("list", yum_lookup_arr)
+      # Verify each package
+      for pkg in desired_packages
+        # DEBUG: puts "checking " + pkg
+        # DEBUG: puts output.grep(/^#{Regexp.escape pkg}/).to_s
+        # All returned packages have arch so we should check if they start with string, not match
+        unless output.grep(/^#{Regexp.escape pkg}/).size > 0
+          return false
+        end
       end
     end
 
     # Test group packages
-    output = pkg_list("grouplist", group_packages)
-    if ! output.size then
-      return false
+    if group_packages.any? then
+      output = pkg_list("grouplist", group_packages)
+      if ! output.size then
+        return false
+      end
     end
 
     # If all packages and groups are already installed return true
@@ -49,7 +53,6 @@ commands :rpm => '/usr/bin/rpm'
       # Use rpm for cleaner output
       cmd << "--query" << "--all" << "--queryformat" << "[%{NAME}.%{ARCH}\n]" << pkg
       output = rpm(cmd).split("\n")
-      # remove duplicates (i.e. kernel-*)
     # fix grouplist output
     elsif arg=="grouplist"
       cmd << "-v" << arg << "-e0" 


### PR DESCRIPTION
Verify package names instead of just verifying package lengths are the same.

Also adds support for packages with architectures in the name (e.g., zsh.x86_64).